### PR TITLE
Array loop key isn't the actual key when looping over views['tokens']

### DIFF
--- a/viewstokens.php
+++ b/viewstokens.php
@@ -195,7 +195,7 @@ function viewstokens_civicrm_tokenValues(&$values, $cids, $job_id = null, $token
     if (class_exists('\Drupal') && \Drupal::hasContainer()) {
       \Drupal::moduleHandler()->loadAll();
       \Drupal::configFactory()->getEditable('system.theme')->set('default', 'vwm_base')->save();
-      foreach($tokens['views'] as $key) {
+      foreach(array_keys($tokens['views']) as $key) {
         list($view_name,$display) = explode('__', $key, 2);
 	/* 
 	 * this section commented out - I'd like to allow the inclusion


### PR DESCRIPTION
The view "slug" that we're looking for is actually the array key, whereas the value is always 1, so it never matches any real view.

This at least outputs something for the matching views that do exist although the output html isn't quite right.